### PR TITLE
Add FailureHandler.

### DIFF
--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.opensearch.sink;
+
+import java.io.Serializable;
+
+public interface FailureHandler extends Serializable {
+    void onFailure(Throwable failure);
+}
+

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
@@ -20,6 +20,9 @@ package org.apache.flink.connector.opensearch.sink;
 
 import java.io.Serializable;
 
+/**
+ * Handler to process failures.
+ */
 public interface FailureHandler extends Serializable {
     void onFailure(Throwable failure);
 }

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/FailureHandler.java
@@ -20,10 +20,7 @@ package org.apache.flink.connector.opensearch.sink;
 
 import java.io.Serializable;
 
-/**
- * Handler to process failures.
- */
+/** Handler to process failures. */
 public interface FailureHandler extends Serializable {
     void onFailure(Throwable failure);
 }
-

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSink.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSink.java
@@ -59,19 +59,22 @@ public class OpensearchSink<IN> implements Sink<IN> {
     private final BulkProcessorConfig buildBulkProcessorConfig;
     private final NetworkClientConfig networkClientConfig;
     private final DeliveryGuarantee deliveryGuarantee;
+    private FailureHandler failureHandler;
 
     OpensearchSink(
             List<HttpHost> hosts,
             OpensearchEmitter<? super IN> emitter,
             DeliveryGuarantee deliveryGuarantee,
             BulkProcessorConfig buildBulkProcessorConfig,
-            NetworkClientConfig networkClientConfig) {
+            NetworkClientConfig networkClientConfig,
+            FailureHandler failureHandler) {
         this.hosts = checkNotNull(hosts);
         checkArgument(!hosts.isEmpty(), "Hosts cannot be empty.");
         this.emitter = checkNotNull(emitter);
         this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
         this.buildBulkProcessorConfig = checkNotNull(buildBulkProcessorConfig);
         this.networkClientConfig = checkNotNull(networkClientConfig);
+        this.failureHandler = failureHandler;
     }
 
     @Override
@@ -83,7 +86,8 @@ public class OpensearchSink<IN> implements Sink<IN> {
                 buildBulkProcessorConfig,
                 networkClientConfig,
                 context.metricGroup(),
-                context.getMailboxExecutor());
+                context.getMailboxExecutor(),
+                failureHandler);
     }
 
     @VisibleForTesting

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
@@ -287,9 +287,9 @@ public class OpensearchSinkBuilder<IN> {
     }
 
     /**
-     * Allows to set custom failure handler.
-     * If not set, or set to null, then the default behavior is preserved:
-     * throwing a runtime exception upon receiving a failure.
+     * Allows to set custom failure handler. If not set, or set to null, then the default behavior
+     * is preserved: throwing a runtime exception upon receiving a failure.
+     *
      * @param failureHandler
      * @return
      */
@@ -311,7 +311,12 @@ public class OpensearchSinkBuilder<IN> {
         BulkProcessorConfig bulkProcessorConfig = buildBulkProcessorConfig();
 
         return new OpensearchSink<>(
-                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig, failureHandler);
+                hosts,
+                emitter,
+                deliveryGuarantee,
+                bulkProcessorConfig,
+                networkClientConfig,
+                failureHandler);
     }
 
     private NetworkClientConfig buildNetworkClientConfig() {

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchSinkBuilder.java
@@ -72,6 +72,7 @@ public class OpensearchSinkBuilder<IN> {
     private Integer connectionRequestTimeout;
     private Integer socketTimeout;
     private Boolean allowInsecure;
+    private FailureHandler failureHandler;
 
     public OpensearchSinkBuilder() {}
 
@@ -286,6 +287,18 @@ public class OpensearchSinkBuilder<IN> {
     }
 
     /**
+     * Allows to set custom failure handler.
+     * If not set, or set to null, then the default behavior is preserved:
+     * throwing a runtime exception upon receiving a failure.
+     * @param failureHandler
+     * @return
+     */
+    public OpensearchSinkBuilder<IN> setFailureHandler(FailureHandler failureHandler) {
+        this.failureHandler = failureHandler;
+        return self();
+    }
+
+    /**
      * Constructs the {@link OpensearchSink} with the properties configured this builder.
      *
      * @return {@link OpensearchSink}
@@ -298,7 +311,7 @@ public class OpensearchSinkBuilder<IN> {
         BulkProcessorConfig bulkProcessorConfig = buildBulkProcessorConfig();
 
         return new OpensearchSink<>(
-                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig);
+                hosts, emitter, deliveryGuarantee, bulkProcessorConfig, networkClientConfig, failureHandler);
     }
 
     private NetworkClientConfig buildNetworkClientConfig() {

--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/OpensearchWriter.java
@@ -346,7 +346,7 @@ class OpensearchWriter<IN> implements SinkWriter<IN> {
         if (chainedFailures == null) {
             return;
         }
-        if( failureHandler == null) {
+        if (failureHandler == null) {
             throw new FlinkRuntimeException(chainedFailures);
         } else {
             failureHandler.onFailure(chainedFailures);

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
@@ -266,7 +266,7 @@ class OpensearchWriterITCase {
                         null,
                         true),
                 metricGroup,
-                new TestMailbox());
+                new TestMailbox(), null);
     }
 
     private static class UpdatingEmitter implements OpensearchEmitter<Tuple2<Integer, String>> {

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterITCase.java
@@ -266,7 +266,8 @@ class OpensearchWriterITCase {
                         null,
                         true),
                 metricGroup,
-                new TestMailbox(), null);
+                new TestMailbox(),
+                null);
     }
 
     private static class UpdatingEmitter implements OpensearchEmitter<Tuple2<Integer, String>> {

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
@@ -130,7 +130,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
         testHarness.open();
@@ -169,7 +168,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
         testHarness.processElement(new StreamRecord<>("msg"));
@@ -207,7 +205,7 @@ public class OpensearchSinkTest {
                                 1,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "1", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "1", 0, 0, 1, true))));
 
         responses.add(
                 createResponse(
@@ -216,7 +214,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "2",
                                         new Exception("artificial failure for record")))));
 
@@ -335,7 +332,7 @@ public class OpensearchSinkTest {
                                 1,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "1", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "1", 0, 0, 1, true))));
 
         // Let the whole bulk request fail
         responses.add(response -> response.setStatusCode(500));
@@ -398,7 +395,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
 
@@ -408,7 +404,7 @@ public class OpensearchSinkTest {
                                 2,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "2", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "2", 0, 0, 1, true))));
 
         testHarness.processElement(new StreamRecord<>("msg"));
 
@@ -474,7 +470,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
 
@@ -514,7 +509,7 @@ public class OpensearchSinkTest {
             Map<java.lang.String, Object> json = new HashMap<>();
             json.put("data", element);
 
-            indexer.add(Requests.indexRequest().index("index").type("type").id("id").source(json));
+            indexer.add(Requests.indexRequest().index("index").id("id").source(json));
         }
     }
 


### PR DESCRIPTION
Here are my changes to add the FailureHandler.
I also did minor fixes in the tests, related to the changes in the Opensearch 2.5.0 (otherwise they did not compile).
In the OpensearchWriterITCase.java:269 I set the failureHandler to null, so the default behavior will be tested. I hope it is OK, because I did test the actual handler in the real runtime environment. However, we can add the actual handler test if necessary.

Also, let's discuss whether I put the FailureHandler interface in the proper package. This interface is pretty generic by its nature, so maybe you want to have it in some other package.
