### PR TITLE
[hotfix] Update flink, flink-shaded, archunit

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,4 +25,4 @@ jobs:
   compile_and_test:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.16.1
+      flink_version: 1.17.0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/flink-connector-opensearch/src/test/resources/archunit.properties
+++ b/flink-connector-opensearch/src/test/resources/archunit.properties
@@ -29,3 +29,5 @@ freeze.store.default.allowStoreUpdate=true
 #freeze.refreeze=true
 
 freeze.store.default.path=archunit-violations
+
+archRule.failOnEmptyShould = false

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@ under the License.
 		
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit5.version>5.9.2</junit5.version>
-		<assertj.version>3.24.2</assertj.version>
+		<assertj.version>3.21.0</assertj.version>
 		<archunit.version>1.0.1</archunit.version>
-		<testcontainers.version>1.17.6</testcontainers.version>
-		<mockito.version>3.4.6</mockito.version>
+		<testcontainers.version>1.17.2</testcontainers.version>
+		<mockito.version>2.21.0</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>1.15.0</japicmp.referenceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,15 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>1.16.1</flink.version>
-		<flink.shaded.version>15.0</flink.shaded.version>
+		<flink.version>1.17.0</flink.version>
+		<flink.shaded.version>16.1</flink.shaded.version>
 		
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
-		<junit5.version>5.8.1</junit5.version>
-		<assertj.version>3.21.0</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
-		<mockito.version>2.21.0</mockito.version>
+		<junit5.version>5.9.2</junit5.version>
+		<assertj.version>3.24.2</assertj.version>
+		<archunit.version>1.0.1</archunit.version>
+		<testcontainers.version>1.17.6</testcontainers.version>
+		<mockito.version>3.4.6</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>1.15.0</japicmp.referenceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@ under the License.
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit5.version>5.9.2</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
-		<archunit.version>1.0.1</archunit.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
 		<mockito.version>2.21.0</mockito.version>
 


### PR DESCRIPTION
The PR bumps dependencies

flink from 1.16.1 to 1.17.0
flink-shaded from 15.0 to 16.1 (same as in flink master)
~assertj from 3.21.0 to 3.24.2 (3.23.1 in flink master)~
archunit from 0.22.0 to 1.0.1 (1.0.0 in flink master)
junit5 from 5.8.1 to 5.9.2 (5.9.1 in flink master)
~testcontainers from 1.17.2 to 1.17.6 (same as in flink master)~
~mockito from 2.21.0 to 3.4.6 (same as in flink master)~

it also adds 
`archRule.failOnEmptyShould = false` since there are breaking changes in archunit 0.23.0 https://github.com/TNG/ArchUnit/releases/tag/v0.23.0
```
As mentioned in Enhancements/Core ArchRules will now by default reject evaluating if the set passed to the should-clause is empty. This will break existing rules that don't check any elements in their should-clause. You can restore the old behavior by setting the ArchUnit property archRule.failOnEmptyShould=false
```