### PR TITLE
[FLINK-31697] OpenSearch nightly CI failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@ under the License.
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
-		<archunit.version>0.22.0</archunit.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
 		<mockito.version>2.21.0</mockito.version>
 
@@ -331,20 +330,6 @@ under the License.
 				<version>${testcontainers.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>com.tngtech.archunit</groupId>
-				<artifactId>archunit</artifactId>
-				<version>${archunit.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>com.tngtech.archunit</groupId>
-				<artifactId>archunit-junit5</artifactId>
-				<version>${archunit.version}</version>
-				<scope>test</scope>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
There was an issue with ArchUnit version: 1.16.1 uses 0.22.0 whereas 1.17.0 uses 1.0.0. The versions are not compatible so the suggestion is to drop explicit ArchUnit version management from connector and rely on `flink-architecture-tests-test` dependencies instead. 