### PR TITLE
[hotfix] Fix nightly build for 1.18-SNAPSHOT, drop 1.16-SNAPSHOT from the nightly matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16.1, 1.17.0]
+        flink: [1.17.0]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/OpensearchUtil.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/OpensearchUtil.java
@@ -43,6 +43,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 
 /** Collection of utility methods for Opensearch tests. */
 @Internal
@@ -161,6 +162,10 @@ public class OpensearchUtil {
         public DynamicTableSink.DataStructureConverter createDataStructureConverter(
                 DataType consumedDataType) {
             return null;
+        }
+
+        public Optional<int[][]> getTargetColumns() {
+            return Optional.empty();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<mockito.version>2.21.0</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
-		<japicmp.referenceVersion>1.15.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.17.0</japicmp.referenceVersion>
 
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
Fixing the compilation issue for 1.18 (see please https://github.com/apache/flink-connector-opensearch/actions/runs/4615625503/jobs/8159702829).

```
Error:  /home/runner/work/flink-connector-opensearch/flink-connector-opensearch/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/OpensearchUtil.java:[144,19] org.apache.flink.connector.opensearch.OpensearchUtil.MockContext is not abstract and does not override abstract method getTargetColumns() in org.apache.flink.table.connector.sink.DynamicTableSink.Context
```

