### PR TITLE
[hotfix] Add opensearch.yml to enable flink to find the data

### DIFF
--- a/docs/data/opensearch.yml
+++ b/docs/data/opensearch.yml
@@ -1,0 +1,21 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variants:
+  - maven: flink-connector-opensearch
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-opensearch/$full_version/flink-sql-connector-opensearch-$full_version.jar


### PR DESCRIPTION
I compiled the flink documentation locally and found the problem shown in the figure below:

<img width="888" alt="image" src="https://user-images.githubusercontent.com/19502505/230966931-7decad8f-c43c-4a3d-bc4f-9f8ad7efb03c.png">

It seems that we used `sql_connector_download_table` shortcode in table document but did not introduce the corresponding yml file. As a result, we get an empty artifact.