### PR TITLE
[hotfix] Use 1.0.0-1.16 baseline for API compatibility checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<mockito.version>2.21.0</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
-		<japicmp.referenceVersion>1.17.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.0.0-1.16</japicmp.referenceVersion>
 
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
Use 1.0.0-1.16 baseline for API compatibility checks