### PR TITLE
[FLINK-32228] Bump testcontainers to 1.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit5.version>5.9.2</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
-		<testcontainers.version>1.18.2</testcontainers.version>
+		<testcontainers.version>1.18.3</testcontainers.version>
 		<mockito.version>2.21.0</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@ under the License.
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-connector-opensearch-parent</artifactId>
 	<version>2.0-SNAPSHOT</version>
 	<name>Flink : Connectors : Opensearch : Parent</name>
@@ -60,10 +59,11 @@ under the License.
 	<properties>
 		<flink.version>1.17.0</flink.version>
 		
+		<commons-compress.version>1.23.0</commons-compress.version>
 		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<junit5.version>5.9.2</junit5.version>
 		<assertj.version>3.21.0</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
+		<testcontainers.version>1.18.2</testcontainers.version>
 		<mockito.version>2.21.0</mockito.version>
 
 		<japicmp.skip>false</japicmp.skip>
@@ -270,6 +270,13 @@ under the License.
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-1.2-api</artifactId>
 				<version>${log4j.version}</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION
Besides bumping testcontainers it also removes redundant tag in pom