### PR TITLE
[FLINK-32425][docs] Fix the empty link in the datastream doc

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/opensearch.md
+++ b/docs/content.zh/docs/connectors/datastream/opensearch.md
@@ -253,7 +253,7 @@ More information about Opensearch can be found [here](https://opensearch.org/).
 
 For the execution of your Flink program, it is recommended to build a
 so-called uber-jar (executable jar) containing all your dependencies
-(see [here]({{< ref "docs/dev/configuration" >}}) for further information).
+(see [here]({{< ref "docs/dev/configuration/overview" >}}) for further information).
 
 Alternatively, you can put the connector's jar file into Flink's `lib/` folder to make it available
 system-wide, i.e. for all job being run.

--- a/docs/content/docs/connectors/datastream/opensearch.md
+++ b/docs/content/docs/connectors/datastream/opensearch.md
@@ -274,7 +274,7 @@ More information about Opensearch can be found [here](https://opensearch.org/).
 
 For the execution of your Flink program, it is recommended to build a
 so-called uber-jar (executable jar) containing all your dependencies
-(see [here]({{< ref "docs/dev/configuration" >}}) for further information).
+(see [here]({{< ref "docs/dev/configuration/overview" >}}) for further information).
 
 Alternatively, you can put the connector's jar file into Flink's `lib/` folder to make it available
 system-wide, i.e. for all job being run.


### PR DESCRIPTION
Fix the empty link in the datastream doc.

There is an empty link("see here for further information") in https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/connectors/datastream/opensearch/. And we should fix this.

The link should be like this ("See how to link with it for cluster execution here.") in https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/connectors/table/opensearch/