### PR TITLE
[FLINK-33020] OpensearchSinkTest.testAtLeastOnceSink timed out

### DIFF
--- a/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
@@ -320,7 +320,7 @@ public class OpensearchSinkTest {
                 new OpensearchSink.Builder<>(
                         Arrays.asList(new HttpHost("localhost", server.getLocalPort())),
                         new SimpleSinkFunction<String>());
-        builder.setBulkFlushInterval(500);
+        builder.setBulkFlushInterval(1000);
         builder.setFailureHandler(new NoOpFailureHandler());
 
         final OpensearchSink<String> sink = builder.build();
@@ -379,7 +379,7 @@ public class OpensearchSinkTest {
                 new OpensearchSink.Builder<>(
                         Arrays.asList(new HttpHost("localhost", server.getLocalPort())),
                         new SimpleSinkFunction<String>());
-        builder.setBulkFlushInterval(500);
+        builder.setBulkFlushInterval(1000);
         // use a failure handler that simply re-adds requests
         builder.setFailureHandler(new DummyRetryFailureHandler());
 
@@ -571,7 +571,7 @@ public class OpensearchSinkTest {
 
     private static void awaitForCondition(Supplier<Boolean> condition) throws InterruptedException {
         while (!condition.get()) {
-            Thread.sleep(10);
+            Thread.sleep(1);
         }
     }
 


### PR DESCRIPTION
Make the polling more aggressive but the flushing less aggressive (on busy CI hosts, such timing doesn't play well)