### PR TITLE
Allow All hostname when ssl set insecure

### DIFF
--- a/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/DefaultRestClientFactory.java
+++ b/flink-connector-opensearch/src/main/java/org/apache/flink/connector/opensearch/sink/DefaultRestClientFactory.java
@@ -24,6 +24,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContexts;
 import org.opensearch.client.RestClientBuilder;
 
@@ -85,8 +86,11 @@ public class DefaultRestClientFactory implements RestClientFactory {
 
         if (networkClientConfig.isAllowInsecure().orElse(false)) {
             try {
-                httpClientBuilder.setSSLContext(
-                        SSLContexts.custom().loadTrustMaterial(new TrustAllStrategy()).build());
+                httpClientBuilder
+                        .setSSLContext(
+                            SSLContexts.custom().loadTrustMaterial(new TrustAllStrategy()).build())
+                        .setSSLHostnameVerifier(
+                            SSLIOSessionStrategy.ALLOW_ALL_HOSTNAME_VERIFIER);
             } catch (final NoSuchAlgorithmException
                     | KeyStoreException
                     | KeyManagementException ex) {


### PR DESCRIPTION
Allow All hostname when ssl set insecure

when we have flink job we insecure cert, we use `setAllowInsecure` to trust all cert. 
but when we using hostname like: "https://ip:port" instead of domain. 
it shows : Host name 'IPV4/IPV6' does not match the certificate subject provided by the peer which is www.xxx.domain

so when `setAllowInsecure` we can use `ALLOW_ALL_HOSTNAME_VERIFIER`