### PR TITLE
[FLINK-34961][BP v.1.1] Use dedicated CI name for Opensearch connector to differentiate it in infra-reports

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: CI
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Flink Connector Opensearch CI
 on: [push, pull_request]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: Nightly
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Weekly Flink Connector Opensearch
 on:
   schedule:
     - cron: "0 0 * * 0"


### PR DESCRIPTION
This is a cherry-picked backport of https://github.com/apache/flink-connector-opensearch/pull/43 to 1.1