### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string …

### DIFF
--- a/docs/data/opensearch.yml
+++ b/docs/data/opensearch.yml
@@ -17,6 +17,7 @@
 ################################################################################
 
 version: 2.0.0-SNAPSHOT
+flink_compatibility: ["1.18", "1.19"]
 variants:
   - maven: flink-connector-opensearch
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-opensearch/$full_version/flink-sql-connector-opensearch-$full_version.jar


### PR DESCRIPTION
…to prevent version comparison mismatch

## Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132
* Add supported version for `flink-connector-opensearch` for v1.18 and 1.19. 
    *  Verified artifacts available on maven: https://mvnrepository.com/artifact/org.apache.flink/flink-connector-opensearch. 
    * Also release note: https://lists.apache.org/thread/v9gxnflhhsr92sf76rt58ob688nnr6mj





## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)