### PR TITLE
[FLINK-40110][opensearch] Bump flink.version to 2.1.2

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.1-SNAPSHOT ]
+        flink: [ 2.1.2, 2.2.1 ]
         jdk: [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         flink_branches: [ {
-          flink: 2.1-SNAPSHOT,
+          flink: 2.4-SNAPSHOT,
           jdk: '11, 17, 21',
           branch: main
         },

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>2.0.0</flink.version>
+		<flink.version>2.1.2</flink.version>
 		<commons-compress.version>1.26.1</commons-compress.version>
 		<jackson-bom.version>2.18.2</jackson-bom.version>
 		<junit5.version>5.11.4</junit5.version>


### PR DESCRIPTION
## What is the purpose of the change

The `flink-connector-parent` bump to 2.0.0 was already done upstream (FLINK-39707). This PR bumps the `flink.version` property itself (still 2.0.0) and the CI matrices that test against it, bringing the connector in line with the currently released Flink 2.1.x/2.2.x lines. Mirrors the equivalent bump done for flink-connector-jdbc (FLINK-40061).

## Brief change log

  - Bumped `flink.version` in `pom.xml` from `2.0.0` to `2.1.2` (every submodule references `${flink.version}`, so this propagates everywhere)
  - Updated `.github/workflows/push_pr.yml` matrix from `[ 2.1-SNAPSHOT ]` to `[ 2.1.2, 2.2.1 ]`, matching flink-connector-kafka's pattern of testing the two latest released Flink patch versions
  - Updated `.github/workflows/weekly.yml` `main`-branch matrix entry from `2.1-SNAPSHOT` to `2.4-SNAPSHOT` (current Flink master snapshot, verified against `apache/flink` master `pom.xml` and release tags showing `release-2.3.0` already cut)

## Verifying this change

This change is already covered by existing tests. Ran locally against `flink.version=2.1.2`:
  - `mvn validate` and `mvn compile` pass for all modules
  - `mvn test` passes for `flink-connector-opensearch-base`, `flink-connector-opensearch3`, and all `flink-sql-connector-opensearch*` modules
  - `flink-connector-opensearch` and `flink-connector-opensearch2` hit a pre-existing `ConnectorRules.CONNECTOR_CLASSES_ONLY_DEPEND_ON_PUBLIC_API` ArchUnit failure (`IndexGeneratorFactory`'s `DataType[]` parameter) — confirmed this reproduces identically on unmodified `main` at `flink.version=2.0.0`, so it is unrelated to this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (Flink version)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-sonnet-5)