### PR TITLE
[Connectors / Opensearch] [FLINK-40189] security vunerability fix in IndexGeneratorFactory.java

### DIFF
--- a/flink-connector-opensearch-base/src/main/java/org/apache/flink/connector/opensearch/table/IndexGeneratorFactory.java
+++ b/flink-connector-opensearch-base/src/main/java/org/apache/flink/connector/opensearch/table/IndexGeneratorFactory.java
@@ -204,10 +204,10 @@ final class IndexGeneratorFactory {
     static class IndexHelper {
         private static final Pattern dynamicIndexPattern = Pattern.compile("\\{[^\\{\\}]+\\}?");
         private static final Pattern dynamicIndexTimeExtractPattern =
-                Pattern.compile(".*\\{.+\\|.*\\}.*");
+                Pattern.compile("[^{]*+\\{[^}|]+\\|[^}]*\\}[^}]*+");
         private static final Pattern dynamicIndexSystemTimeExtractPattern =
                 Pattern.compile(
-                        ".*\\{\\s*(now\\(\\s*\\)|NOW\\(\\s*\\)|current_timestamp|CURRENT_TIMESTAMP)\\s*\\|.*\\}.*");
+                        "[^{]*+\\{\\s*+(now\\(\\s*+\\)|NOW\\(\\s*+\\)|current_timestamp|CURRENT_TIMESTAMP)\\s*+\\|[^}]*\\}[^}]*+");
         private static final List<LogicalTypeRoot> supportedTypes = new ArrayList<>();
         private static final Map<LogicalTypeRoot, String> defaultFormats = new HashMap<>();
 


### PR DESCRIPTION
found Two regex patterns which are vulnerable to catastrophic backtracking (polynomial/exponential runtime):
  Pattern.compile(".\\\{.+\\|.
}.*");
Pattern.compile(".\\\{\\s(now\\(\\s*\\)|NOW\\(\\s*\\)|current_timestamp|CURRENT_TIMESTAMP)\\s*\\|.
}.");

This checkin fixes that issue